### PR TITLE
feat: use ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See how it gets used during the [`zarf-init`](https://docs.zarf.dev/commands/zar
 ## What does it do?
 
 ```sh
-zarf-injector <SHA256> [use_ipv6]
+zarf-injector <SHA256> [ipv6_bind]
 ```
 
 The `zarf-injector` binary serves 2 purposes during 'init'.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See how it gets used during the [`zarf-init`](https://docs.zarf.dev/commands/zar
 ## What does it do?
 
 ```sh
-zarf-injector <SHA256>
+zarf-injector <SHA256> [use_ipv6]
 ```
 
 The `zarf-injector` binary serves 2 purposes during 'init'.

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,7 +266,7 @@ async fn main() {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
-        println!("Usage: {} <sha256sum> [use_ipv6]", args[0]);
+        println!("Usage: {} <sha256sum> [ipv6_bind]", args[0]);
         return;
     }
 
@@ -274,8 +274,8 @@ async fn main() {
     let payload_sha = &args[1];
 
     // assume IPv4 unless specified
-    let use_ipv6 = args.get(2).map_or(false, |arg| arg == "true");
-    let bind_addr = if use_ipv6 {
+    let ipv6_bind = args.get(2).map_or(false, |arg| arg == "true");
+    let bind_addr = if ipv6_bind {
         "[::]:5000"
     } else {
         "0.0.0.0:5000"

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,15 +265,27 @@ async fn handle_get_digest(tag: String) -> Response {
 async fn main() {
     let args: Vec<String> = env::args().collect();
 
+    if args.len() < 2 {
+        println!("Usage: {} <sha256sum> [use_ipv6]", args[0]);
+        return;
+    }
+
     println!("unpacking: {}", args[1]);
     let payload_sha = &args[1];
 
+    // assume IPv4 unless specified
+    let use_ipv6 = args.get(2).map_or(false, |arg| arg == "true");
+    let bind_addr = if use_ipv6 {
+        "[::]:5000"
+    } else {
+        "0.0.0.0:5000"
+    };
+
     unpack(payload_sha);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:5000").await.unwrap();
+    let listener = tokio::net::TcpListener::bind(bind_addr).await.unwrap();
     println!("listening on {}", listener.local_addr().unwrap());
     axum::serve(listener, start_seed_registry()).await.unwrap();
-    println!("Usage: {} <sha256sum>", args[1]);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This allows users to use an IPv6 address. Most of the time [::1] will work for IPv4 hosts also, but out of an abundance of caution, I made it so the user has the explicitly state that they want the ipv6 binding