### PR TITLE
chore: bump futures-util@0.3.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,15 +374,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -397,15 +397,15 @@ checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-macro",


### PR DESCRIPTION
Running `cargo audit` I noticed `futures-util` was pointing to a yanked version, which indicates that it was a problematic release, so upgrading seemed like the right thing to do here:
```shell
$ cargo audit
...
Crate:     futures-util
Version:   0.3.30
Warning:   yanked
Dependency tree:
futures-util 0.3.30
├── zarf-injector 0.0.0
├── tower 0.4.13
│   ├── hyper-util 0.1.5
│   │   ├── hyperlocal 0.9.1
│   │   │   └── bollard 0.17.1
│   │   │       └── zarf-injector 0.0.0
│   │   ├── hyper-named-pipe 0.1.0
│   │   │   └── bollard 0.17.1
│   │   ├── bollard 0.17.1
│   │   └── axum 0.7.5
│   │       └── zarf-injector 0.0.0
│   └── axum 0.7.5
├── hyper-util 0.1.5
├── hyper 1.3.1
│   ├── hyperlocal 0.9.1
│   ├── hyper-util 0.1.5
│   ├── hyper-named-pipe 0.1.0
│   ├── bollard 0.17.1
│   └── axum 0.7.5
├── bollard 0.17.1
├── axum-core 0.4.3
│   └── axum 0.7.5
└── axum 0.7.5
```