### PR TITLE
ci: injector setup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,6 @@ jobs:
         
       - name: "Build Rust Binary for x86_64 and arm64"
         run: |
-          make install-cross
+          make setup
           make injector
           make check-size

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: "Build injector"
         run: |
-          make install-cross
+          make setup
           make injector
 
       - name: "Rename binaries"

--- a/.github/workflows/test-init.yaml
+++ b/.github/workflows/test-init.yaml
@@ -12,7 +12,7 @@ jobs:
 
       - name: "Build injector"
         run: |
-          make install-cross
+          make setup
           make injector
 
       - name: "Upload injector artifacts"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -12,5 +12,5 @@ jobs:
         
       - name: "Build Rust Binary for x86_64 and arm64"
         run: |
-          make install-cross
+          make setup
           make unit-test

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,17 @@ help: ## Display this help information
 clean: ## Clean the build directory
 	rm -rf target
 
+install-rust: ## Install Rust via rustup
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+install-targets: ## Add required Rust targets
+	rustup target add x86_64-unknown-linux-musl
+	rustup target add aarch64-unknown-linux-musl
+
 install-cross: ## installs cross
 	cargo install cross --git https://github.com/cross-rs/cross
+
+setup: install-rust install-targets install-cross ## Install all dependencies
 
 injector: injector-amd injector-arm ## Builds the injector for both platforms
 
@@ -42,10 +51,8 @@ unit-test: ## Run cargo tests
 	cargo test 	
 
 target/x86_64-unknown-linux-musl/release/zarf-injector: src/main.rs Cargo.toml
-	rustup target add x86_64-unknown-linux-musl
 	cross build --target x86_64-unknown-linux-musl --release
 
 target/aarch64-unknown-linux-musl/release/zarf-injector: src/main.rs Cargo.toml
-	rustup target add aarch64-unknown-linux-musl
 	cross build --target aarch64-unknown-linux-musl --release
 


### PR DESCRIPTION
This provides a single make target `setup` that installs all the required dependencies and avoids relying on the github action runner default version of rust